### PR TITLE
Disable Android `GradleDependency` lint check

### DIFF
--- a/khronicle-android/build.gradle.kts
+++ b/khronicle-android/build.gradle.kts
@@ -35,5 +35,7 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+
+        disable += "GradleDependency"
     }
 }


### PR DESCRIPTION
There is no need to fail builds/CI due to outdated dependencies.