### PR TITLE
Remove workaround for `jvmToolchain` not being honored pre AGP 8.1.0-alpha09

### DIFF
--- a/khronicle-android/build.gradle.kts
+++ b/khronicle-android/build.gradle.kts
@@ -20,13 +20,6 @@ kotlin {
 }
 
 android {
-    // Workaround (for `jvmToolchain` not being honored) needed until AGP 8.1.0-alpha09.
-    // https://kotlinlang.org/docs/gradle-configure-project.html#gradle-java-toolchains-support
-    compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
     compileSdk = libs.versions.android.compile.get().toInt()
     defaultConfig.minSdk = 16
 


### PR DESCRIPTION
We've upgraded Android Gradle plugin (AGP) beyond the versions that needed the workaround.