### PR TITLE
Remove explicit `POM_ARTIFACT_ID` configuration

### DIFF
--- a/khronicle-android/gradle.properties
+++ b/khronicle-android/gradle.properties
@@ -1,1 +1,0 @@
-POM_ARTIFACT_ID=khronicle-android

--- a/khronicle-core/gradle.properties
+++ b/khronicle-core/gradle.properties
@@ -1,1 +1,0 @@
-POM_ARTIFACT_ID=khronicle-core

--- a/khronicle-ktor-client/gradle.properties
+++ b/khronicle-ktor-client/gradle.properties
@@ -1,1 +1,0 @@
-POM_ARTIFACT_ID=khronicle-ktor-client


### PR DESCRIPTION
The Maven artifact name defaults to the module name, so the module `gradle.properties` files are superfluous when the `POM_ARTIFACT_ID` matches the module name.

Tested with a local Maven publish:

```bash
$ ./gradlew -PRELEASE_SIGNING_ENABLED=false -PVERSION_NAME=0.1.0 publishToMavenLocal
$ ls --tree -D -L 4 ~/.m2/repository/com/juul/

 /Users/travis.wyatt/.m2/repository/com/juul
└──  khronicle
   ├──  khronicle-android
   │  └──  0.1.0
   ├──  khronicle-android-android
   │  └──  0.1.0
   ├──  khronicle-android-android-debug
   │  └──  0.1.0
   ├──  khronicle-core
   │  └──  0.1.0
   ├──  khronicle-core-iosarm64
   │  └──  0.1.0
   ├──  khronicle-core-iossimulatorarm64
   │  └──  0.1.0
   ├──  khronicle-core-iosx64
   │  └──  0.1.0
   ├──  khronicle-core-js
   │  └──  0.1.0
   ├──  khronicle-core-jvm
   │  └──  0.1.0
   ├──  khronicle-core-macosarm64
   │  └──  0.1.0
   ├──  khronicle-core-macosx64
   │  └──  0.1.0
   ├──  khronicle-ktor-client
   │  └──  0.1.0
   ├──  khronicle-ktor-client-iosarm64
   │  └──  0.1.0
   ├──  khronicle-ktor-client-iossimulatorarm64
   │  └──  0.1.0
   ├──  khronicle-ktor-client-iosx64
   │  └──  0.1.0
   ├──  khronicle-ktor-client-js
   │  └──  0.1.0
   ├──  khronicle-ktor-client-jvm
   │  └──  0.1.0
   ├──  khronicle-ktor-client-macosarm64
   │  └──  0.1.0
   └──  khronicle-ktor-client-macosx64
      └──  0.1.0
```