### PR TITLE
Update AtomicFU configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,14 @@ buildscript {
         google()
         mavenCentral()
     }
+    dependencies {
+        classpath(libs.atomicfu)
+    }
 }
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.android.publish) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlin = "1.9.22"
 ktor = "2.3.8"
 
 [libraries]
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version = "0.23.1" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.8.0" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
@@ -14,7 +15,6 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 android-library = { id = "com.android.library", version = "8.3.0" }
 android-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-atomicfu = { id = "kotlinx-atomicfu", version = "0.23.1" }
 binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.13.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,9 +12,6 @@ pluginManagement {
                 "binary-compatibility-validator" ->
                     useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
 
-                "kotlinx-atomicfu" ->
-                    useModule("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${requested.version}")
-
                 else -> when (requested.id.namespace) {
                     "com.android" ->
                         useModule("com.android.tools.build:gradle:${requested.version}")


### PR DESCRIPTION
Now pulling in AtomicFU via `classpath` in `buildscript.dependencies` as it more closely aligns with official [setup instructions](https://github.com/Kotlin/kotlinx-atomicfu?tab=readme-ov-file#apply-plugin).

Hopefully this fixes its discoverability with Renovate so that we get automatic dependency update PRs. 🤞 