### PR TITLE
Simplify `binary-compatibility-validator` setup

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,9 +12,9 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlinter) apply false
-    alias(libs.plugins.dokka)
     alias(libs.plugins.android.publish) apply false
-    alias(libs.plugins.binary.compatibility.validator)
+    alias(libs.plugins.api)
+    alias(libs.plugins.dokka)
 }
 
 allprojects {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,12 +3,14 @@ buildscript {
         google()
         mavenCentral()
     }
+    dependencies {
+        classpath(libs.atomicfu)
+    }
 }
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.kotlinter) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.android.publish) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ kotlin = "1.9.22"
 ktor = "2.3.8"
 
 [libraries]
+atomicfu = { module = "org.jetbrains.kotlinx:atomicfu-gradle-plugin", version = "0.23.1" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version = "1.8.0" }
 ktor-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-logging = { module = "io.ktor:ktor-client-logging", version.ref = "ktor" }
@@ -14,7 +15,6 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 android-library = { id = "com.android.library", version = "8.3.0" }
 android-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-atomicfu = { id = "kotlinx-atomicfu", version = "0.23.1" }
 binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.13.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ ktor-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 [plugins]
 android-library = { id = "com.android.library", version = "8.3.0" }
 android-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }
-binary-compatibility-validator = { id = "binary-compatibility-validator", version = "0.13.0" }
+api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.0" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.10" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.2.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,15 +8,8 @@ pluginManagement {
 
     resolutionStrategy {
         eachPlugin {
-            when (requested.id.id) {
-                "binary-compatibility-validator" ->
-                    useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
-
-                else -> when (requested.id.namespace) {
-                    "com.android" ->
-                        useModule("com.android.tools.build:gradle:${requested.version}")
-                }
-            }
+            if (requested.id.namespace == "com.android")
+                useModule("com.android.tools.build:gradle:${requested.version}")
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,9 +12,6 @@ pluginManagement {
                 "binary-compatibility-validator" ->
                     useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
 
-                "kotlinx-atomicfu" ->
-                    useModule("org.jetbrains.kotlinx:atomicfu-gradle-plugin:${requested.version}")
-
                 else -> when (requested.id.namespace) {
                     "com.android" ->
                         useModule("com.android.tools.build:gradle:${requested.version}")


### PR DESCRIPTION
Updates configuration to more closely match [official setup instructions](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file#setup) (by not configuring/using a shorthand name for the plugin — in other words: no longer using `resolutionStrategy`).

Hopefully this fixes its discoverability with Renovate so that we get automatic dependency update PRs. 🤞 