### PR TITLE
Configure Codecov token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
           arguments: assemble check jacocoTestReport
 
       - uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: publishToMavenLocal
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Seeing [failures on CI](https://github.com/JuulLabs/khronicle/actions/runs/8145237442/job/22261032598):

```
..
Error: Codecov token not found. Please provide Codecov token with -t flag.
Warning: Codecov: Failed to properly create commit: The process '/Users/runner/work/_actions/codecov/codecov-action/v4/dist/codecov' failed with exit code 1
```

I had previously thought that public repos didn't need the token, but I either was mistaken, or things have changed. 🤷 
Either way, this should provide the token and make Codecov happy. 🤞 