### PR TITLE
Fix JaCoCo test report coverage

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ allprojects {
                 xml.required.set(true)
             }
 
-            classDirectories.setFrom(layout.buildDirectory.file("classes/kotlin/jvm/main"))
+            classDirectories.setFrom(layout.buildDirectory.file("classes/atomicfu-orig/jvm/main"))
             sourceDirectories.setFrom(layout.projectDirectory.files("src/commonMain", "src/jvmMain"))
             executionData.setFrom(layout.buildDirectory.file("jacoco/jvmTest.exec"))
 


### PR DESCRIPTION
Coverage was being reported as 0% because JaCoCo could not find `.class` files — when AtomicFU Gradle plugin is applied, the `.class` files are output to `classes/atomicfu-orig` directory instead of `classes/kotlin`.

<details>
<summary>Without AtomicFU Gradle plugin</summary>

Tested by making the following `khronicle-core/build.gradle.kts` changes:

```diff
  plugins {
      // ..
-     id("kotlinx-atomicfu")
  }
  
  kotlin {
      // ..
      sourceSets {
          // ..
          commonMain.dependencies {
+             implementation("org.jetbrains.kotlinx:atomicfu:0.23.1")
          }
      }
  }
```

Class files are where I traditionally have known them to be:

```bash
$ find . -type f -name '*.class'

..
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Log$WhenMappings.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Metadata.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Sensitivity$Companion.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/FilterLogger.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Log.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Sensitivity.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/ReadMetadata.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/LogKt$metadataPool$2.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger$debug$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/FilterLevelLoggerKt.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/LogKt.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Logger.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/HideFromStackTraceTag.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger$error$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger$info$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/LogLevel.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/StackTraceTagGenerator.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/LogKt$metadataPool$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger$assert$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/KhronicleInternal.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/WriteMetadata.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Key.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/ConstantTagGenerator.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Pool.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/TagGenerator.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/FilterLoggerKt.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLoggerKt.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatcherState$logLevel$2.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/CallListLogger.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatcherState.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/StackTraceTagGenerator$getTag$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/LogFilter.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Logger$DefaultImpls.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/ConsoleLogger.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger$verbose$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/DispatchLogger$warn$1.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/Call.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/StackTraceTagGeneratorKt.class
./khronicle-core/build/classes/kotlin/jvm/main/com/juul/khronicle/FilterLevelLogger.class
..
```
</details>

<details>
<summary>With AtomicFU Gradle plugin</summary>

With the AtomicFU Gradle plugin applied, class files are relocated:

```bash
$ find . -type f -name '*.class'
..
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Log$WhenMappings.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Metadata.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Sensitivity$Companion.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/FilterLogger.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Log.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Sensitivity.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/ReadMetadata.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/LogKt$metadataPool$2.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Log$AtomicTagGeneratorRefVolatile.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger$debug$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/FilterLevelLoggerKt.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/LogKt.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Logger.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/HideFromStackTraceTag.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger$error$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger$info$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/LogLevel.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/StackTraceTagGenerator.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/LogKt$metadataPool$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger$assert$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/KhronicleInternal.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/WriteMetadata.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Key.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/ConstantTagGenerator.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Pool.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/TagGenerator.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/FilterLoggerKt.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLoggerKt.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatcherState$logLevel$2.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/CallListLogger.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatcherState.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/StackTraceTagGenerator$getTag$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/LogFilter.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Logger$DefaultImpls.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/ConsoleLogger.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger$verbose$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/DispatchLogger$warn$1.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/Call.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/StackTraceTagGeneratorKt.class
./khronicle-core/build/classes/atomicfu/jvm/main/com/juul/khronicle/FilterLevelLogger.class
..
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Log$WhenMappings.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Metadata.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Sensitivity$Companion.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/FilterLogger.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Log.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Sensitivity.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/ReadMetadata.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/LogKt$metadataPool$2.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger$debug$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/FilterLevelLoggerKt.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/LogKt.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Logger.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/HideFromStackTraceTag.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger$error$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger$info$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/LogLevel.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/StackTraceTagGenerator.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/LogKt$metadataPool$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger$assert$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/KhronicleInternal.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/WriteMetadata.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Key.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/ConstantTagGenerator.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Pool.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/TagGenerator.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/FilterLoggerKt.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLoggerKt.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatcherState$logLevel$2.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/CallListLogger.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatcherState.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/StackTraceTagGenerator$getTag$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/LogFilter.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Logger$DefaultImpls.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/ConsoleLogger.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger$verbose$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/DispatchLogger$warn$1.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/Call.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/StackTraceTagGeneratorKt.class
./khronicle-core/build/classes/atomicfu-orig/jvm/main/com/juul/khronicle/FilterLevelLogger.class
```
</details>

Using `classes/atomicfu` results in the following JaCoCo errors (and under reported coverage):

```
[ant:jacocoReport] Classes in bundle 'khronicle-core' do not match with execution data. For report generation the same class files must be used as at runtime.
[ant:jacocoReport] Execution data for class com/juul/khronicle/CallListLogger does not match.
[ant:jacocoReport] Execution data for class com/juul/khronicle/Log does not match.
[ant:jacocoReport] Execution data for class com/juul/khronicle/DispatchLogger does not match.
[ant:jacocoReport] Execution data for class com/juul/khronicle/Pool does not match.
```

While using `classes/atmoicfu-orig` properly reports coverage.