### PR TITLE
Add WasmJS target

### DIFF
--- a/khronicle-core/api/khronicle-core.api
+++ b/khronicle-core/api/khronicle-core.api
@@ -132,6 +132,17 @@ public final class com/juul/khronicle/Logger$DefaultImpls {
 	public static fun getMinimumLogLevel (Lcom/juul/khronicle/Logger;)Lcom/juul/khronicle/LogLevel;
 }
 
+public final class com/juul/khronicle/PrintlnLogger : com/juul/khronicle/HideFromStackTraceTag, com/juul/khronicle/Logger {
+	public static final field INSTANCE Lcom/juul/khronicle/PrintlnLogger;
+	public fun assert (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
+	public fun debug (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
+	public fun error (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
+	public fun getMinimumLogLevel ()Lcom/juul/khronicle/LogLevel;
+	public fun info (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
+	public fun verbose (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
+	public fun warn (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
+}
+
 public abstract interface class com/juul/khronicle/ReadMetadata {
 	public abstract fun copy ()Lcom/juul/khronicle/ReadMetadata;
 	public abstract fun get (Lcom/juul/khronicle/Key;)Ljava/lang/Object;

--- a/khronicle-core/build.gradle.kts
+++ b/khronicle-core/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
     jvm()
     macosArm64()
     macosX64()
+    wasmJs().browser()
 
     sourceSets {
         all {

--- a/khronicle-core/src/commonMain/kotlin/ConsoleLogger.kt
+++ b/khronicle-core/src/commonMain/kotlin/ConsoleLogger.kt
@@ -1,4 +1,4 @@
 package com.juul.khronicle
 
-/** Logger for the console. */
+/** Logger for the console, taking advantage of available features such as stderr or js console levels. */
 public expect object ConsoleLogger : Logger

--- a/khronicle-core/src/commonMain/kotlin/PrintlnLogger.kt
+++ b/khronicle-core/src/commonMain/kotlin/PrintlnLogger.kt
@@ -1,0 +1,41 @@
+package com.juul.khronicle
+
+/** Alternative to [ConsoleLogger] that does not take advantage of extra available features. */
+public object PrintlnLogger : Logger, HideFromStackTraceTag {
+
+    override fun verbose(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        print('V', tag, message, throwable)
+    }
+
+    override fun debug(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        print('D', tag, message, throwable)
+    }
+
+    override fun info(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        print('I', tag, message, throwable)
+    }
+
+    override fun warn(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        print('W', tag, message, throwable)
+    }
+
+    override fun error(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        print('E', tag, message, throwable)
+    }
+
+    override fun assert(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
+        print('A', tag, message, throwable)
+    }
+
+    private fun print(
+        level: Char,
+        tag: String,
+        message: String,
+        throwable: Throwable?,
+    ) {
+        when (throwable) {
+            null -> println("[$level/$tag] $message")
+            else -> println("[$level/$tag] $message: ${throwable.stackTraceToString()}")
+        }
+    }
+}

--- a/khronicle-core/src/wasmJsMain/kotlin/ConsoleLogger.kt
+++ b/khronicle-core/src/wasmJsMain/kotlin/ConsoleLogger.kt
@@ -1,0 +1,3 @@
+package com.juul.khronicle
+
+public actual object ConsoleLogger : Logger by PrintlnLogger, HideFromStackTraceTag

--- a/khronicle-core/src/wasmJsMain/kotlin/DefaultTagGenerator.kt
+++ b/khronicle-core/src/wasmJsMain/kotlin/DefaultTagGenerator.kt
@@ -1,0 +1,4 @@
+package com.juul.khronicle
+
+internal actual val defaultTagGenerator: TagGenerator =
+    ConstantTagGenerator("Unknown")


### PR DESCRIPTION
The `PrintlnLogger` implementation was kept available separate from the Wasm `ConsoleLogger` because it's a useful tool in it's own right. As an example, in JS tests `println` is not swallowed by the testing framework even though `console.info` is.