### PR TITLE
Disable `AndroidGradlePluginVersion` lint check

### DIFF
--- a/khronicle-android/build.gradle.kts
+++ b/khronicle-android/build.gradle.kts
@@ -29,6 +29,7 @@ android {
         abortOnError = true
         warningsAsErrors = true
 
+        disable += "AndroidGradlePluginVersion"
         disable += "GradleDependency"
     }
 }


### PR DESCRIPTION
Failing a build due to an outdated Android Gradle plugin (AGP) is excessive/unnecessary.