### PR TITLE
Better object allocation behavior

### DIFF
--- a/khronicle-core/src/commonMain/kotlin/DispatchLogger.kt
+++ b/khronicle-core/src/commonMain/kotlin/DispatchLogger.kt
@@ -1,5 +1,11 @@
 package com.juul.khronicle
 
+import com.juul.khronicle.LogLevel.Assert
+import com.juul.khronicle.LogLevel.Debug
+import com.juul.khronicle.LogLevel.Error
+import com.juul.khronicle.LogLevel.Info
+import com.juul.khronicle.LogLevel.Verbose
+import com.juul.khronicle.LogLevel.Warn
 import kotlinx.atomicfu.atomic
 import kotlinx.atomicfu.update
 
@@ -8,10 +14,8 @@ private val EMPTY_STATE = DispatcherState(emptySet())
 private data class DispatcherState(
     val consumers: Set<Logger>,
 ) {
-    val logLevel: LogLevel by lazy {
-        consumers.minOfOrNull { it.minimumLogLevel }
-            ?: LogLevel.Assert
-    }
+    val logLevel: LogLevel =
+        consumers.minOfOrNull { it.minimumLogLevel } ?: Assert
 }
 
 /** Implementation of [Logger] which dispatches calls to consumer [Logger]s. */
@@ -36,39 +40,62 @@ public class DispatchLogger : Logger {
         state.value = EMPTY_STATE
     }
 
+    // This class looks like a great candidate for SimpleLogger, but we can avoid a few function
+    // calls and conditionals by explicitly writing the different verbose/debug/etc functions.
+    // Normally I try not to worry about optimization at this level, but it can really make a
+    // difference if logging gets placed in a tight loop.
+
     override fun verbose(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
-        state.value.consumers.asSequence()
-            .filter { it.minimumLogLevel <= LogLevel.Verbose }
-            .forEach { it.verbose(tag, message, metadata, throwable) }
+        // Avoid asSequence, filter, etc to keep this as close to allocation free as possible.
+        for (logger in state.value.consumers) {
+            if (logger.minimumLogLevel <= Verbose) {
+                logger.verbose(tag, message, metadata, throwable)
+            }
+        }
     }
 
     override fun debug(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
-        state.value.consumers.asSequence()
-            .filter { it.minimumLogLevel <= LogLevel.Debug }
-            .forEach { it.debug(tag, message, metadata, throwable) }
+        // Avoid asSequence, filter, etc to keep this as close to allocation free as possible.
+        for (logger in state.value.consumers) {
+            if (logger.minimumLogLevel <= Debug) {
+                logger.debug(tag, message, metadata, throwable)
+            }
+        }
     }
 
     override fun info(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
-        state.value.consumers.asSequence()
-            .filter { it.minimumLogLevel <= LogLevel.Info }
-            .forEach { it.info(tag, message, metadata, throwable) }
+        // Avoid asSequence, filter, etc to keep this as close to allocation free as possible.
+        for (logger in state.value.consumers) {
+            if (logger.minimumLogLevel <= Info) {
+                logger.info(tag, message, metadata, throwable)
+            }
+        }
     }
 
     override fun warn(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
-        state.value.consumers.asSequence()
-            .filter { it.minimumLogLevel <= LogLevel.Warn }
-            .forEach { it.warn(tag, message, metadata, throwable) }
+        // Avoid asSequence, filter, etc to keep this as close to allocation free as possible.
+        for (logger in state.value.consumers) {
+            if (logger.minimumLogLevel <= Warn) {
+                logger.warn(tag, message, metadata, throwable)
+            }
+        }
     }
 
     override fun error(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
-        state.value.consumers.asSequence()
-            .filter { it.minimumLogLevel <= LogLevel.Error }
-            .forEach { it.error(tag, message, metadata, throwable) }
+        // Avoid asSequence, filter, etc to keep this as close to allocation free as possible.
+        for (logger in state.value.consumers) {
+            if (logger.minimumLogLevel <= Error) {
+                logger.error(tag, message, metadata, throwable)
+            }
+        }
     }
 
     override fun assert(tag: String, message: String, metadata: ReadMetadata, throwable: Throwable?) {
-        state.value.consumers.asSequence()
-            .filter { it.minimumLogLevel <= LogLevel.Assert }
-            .forEach { it.assert(tag, message, metadata, throwable) }
+        // Avoid asSequence, filter, etc to keep this as close to allocation free as possible.
+        for (logger in state.value.consumers) {
+            if (logger.minimumLogLevel <= Assert) {
+                logger.assert(tag, message, metadata, throwable)
+            }
+        }
     }
 }

--- a/khronicle-core/src/commonMain/kotlin/Log.kt
+++ b/khronicle-core/src/commonMain/kotlin/Log.kt
@@ -2,9 +2,7 @@ package com.juul.khronicle
 
 import com.juul.khronicle.Log.dispatcher
 import kotlinx.atomicfu.atomic
-import kotlin.native.concurrent.ThreadLocal
 
-@ThreadLocal // Thread local pool means that metadata returned from it are safe to mutate on that same thread.
 private val metadataPool = Pool(factory = ::Metadata, refurbish = Metadata::clear)
 
 /** Global logging object. To receive logs, call [dispatcher].[install][DispatchLogger.install]. */

--- a/khronicle-core/src/commonMain/kotlin/Pool.kt
+++ b/khronicle-core/src/commonMain/kotlin/Pool.kt
@@ -3,7 +3,6 @@ package com.juul.khronicle
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
 
-/** While a [Pool] is logically thread safe, Kotlin/Native's memory model requires @ThreadLocal on instances of this. */
 internal class Pool<T>(
     private val factory: () -> T,
     private val refurbish: (T) -> Unit,


### PR DESCRIPTION
Two changes here:
- Removes two allocations in each call to `DispatchLogger.verbose` (and similar) by avoiding `asSequence`/`filter` in favor of a boring, traditional `for` loop. Will only really make a difference if allocating in a tight loop.
- Removes `@ThreadLocal` from the metadata pool instance. This was necessary back when Kotlin/Native used the legacy memory model, but hasn't been necessary for a while. This isn't going to make as big of a difference as the other change, just a few allocations per thread, but reducing the amount of platform-specific behavior is a win anyways.