### PR TITLE
Migrate to `gradle/actions/setup-gradle`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,20 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: assemble
-        uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
-          arguments: assemble check jacocoTestReport
+          validate-wrappers: true
+
+      - run: ./gradlew assemble
+      - run: ./gradlew check
+      - run: ./gradlew jacocoTestReport
 
       - uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-      - name: publishToMavenLocal
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: |
-            -PRELEASE_SIGNING_ENABLED=false
-            publishToMavenLocal
+      - run: ./gradlew -PRELEASE_SIGNING_ENABLED=false publishToMavenLocal

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -9,17 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: dokkaHtmlMultiModule
-        uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: true
-          arguments: dokkaHtmlMultiModule
+
+      - run: ./gradlew dokkaHtmlMultiModule
 
       - uses: JamesIves/github-pages-deploy-action@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,24 +9,20 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
+      - uses: gradle/actions/setup-gradle@v3
 
-      - name: check
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: check
+      - run: ./gradlew check
 
       - name: publish
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: |
-            -PVERSION_NAME=${{ github.ref_name }}
-            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
-            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
-            -PmavenCentralUsername=${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}
-            -PmavenCentralPassword=${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}
-            publish
+        run: >
+          ./gradlew
+          -PVERSION_NAME='${{ github.ref_name }}'
+          -PsigningInMemoryKey='${{ secrets.SIGNING_KEY }}'
+          -PsigningInMemoryKeyPassword='${{ secrets.SIGNING_PASSWORD }}'
+          -PmavenCentralUsername='${{ secrets.OSS_SONATYPE_NEXUS_USERNAME }}'
+          -PmavenCentralPassword='${{ secrets.OSS_SONATYPE_NEXUS_PASSWORD }}'
+          publish

--- a/.github/workflows/signing.yml
+++ b/.github/workflows/signing.yml
@@ -10,17 +10,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v3
       - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'
-
-      - name: publishToMavenLocal
-        uses: gradle/gradle-build-action@v3
+      - uses: gradle/actions/setup-gradle@v3
         with:
           cache-read-only: true
-          arguments: |
-            -PsigningInMemoryKey=${{ secrets.SIGNING_KEY }}
-            -PsigningInMemoryKeyPassword=${{ secrets.SIGNING_PASSWORD }}
-            publishToMavenLocal
+
+      - name: publishToMavenLocal
+        run: >
+          ./gradlew
+          -PsigningInMemoryKey='${{ secrets.SIGNING_KEY }}'
+          -PsigningInMemoryKeyPassword='${{ secrets.SIGNING_PASSWORD }}'
+          publishToMavenLocal


### PR DESCRIPTION
The currently used [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action/blob/main/README.md) is deprecated in favor of [`gradle/actions/setup-gradle`](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md).