### PR TITLE
Store build reports as artifact on test failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,15 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew assemble
+
       - run: ./gradlew check
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: build-reports
+          path: '**/build/reports/*'
+          retention-days: 5
+
       - run: ./gradlew jacocoTestReport
 
       - uses: codecov/codecov-action@v4


### PR DESCRIPTION
Tests are failing in #78, but we need to save the test reports to investigate why.