### PR TITLE
Publish `khronicle-android-lint` artifact

### DIFF
--- a/khronicle-android-lint/build.gradle.kts
+++ b/khronicle-android-lint/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
-    id("com.android.lint")
     kotlin("jvm")
+    id("com.android.lint")
+    id("com.vanniktech.maven.publish")
     id("org.jmailen.kotlinter")
 }
 


### PR DESCRIPTION
A simple oversight in #83, whereas the new `khronicle-android-lint` artifact was not configured to be published to Maven.