### PR TITLE
Add details about Ktor logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,12 @@ Log.warn { metadata ->
 }
 ```
 
-### Ktor
+### [Ktor](https://ktor.io/)
 
-A basic `KtorLogger` is available via the `com.juul.khronicle:khronicle-ktor-client:$version` artifact:
+A basic `KtorLogger` is available via the `com.juul.khronicle:khronicle-ktor-client:$version` artifact.
+
+To route a Ktor [`HttpClient`] instance's logs to Khronicle for logging, simply set
+`KhronicleKtorClientLogger` as the [`HttpClient`]'s logger:
 
 ```kotlin
 HttpClient {
@@ -146,3 +149,9 @@ HttpClient {
     }
 }
 ```
+
+This will cause the [`HttpClient`]'s logs to be sent to installed Khronicle log dispatchers
+(`Log.dispatcher.install`).
+
+
+[`HttpClient`]: https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client/-http-client/index.html

--- a/README.md
+++ b/README.md
@@ -135,11 +135,11 @@ Log.warn { metadata ->
 }
 ```
 
-### [Ktor](https://ktor.io/)
+### [Ktor]
 
 A basic `KtorLogger` is available via the `com.juul.khronicle:khronicle-ktor-client:$version` artifact.
 
-To route a Ktor [`HttpClient`] instance's logs to Khronicle for logging, simply set
+To route a [Ktor] [`HttpClient`] instance's logs to Khronicle for logging, simply set
 `KhronicleKtorClientLogger` as the [`HttpClient`]'s logger:
 
 ```kotlin
@@ -154,4 +154,5 @@ This will cause the [`HttpClient`]'s logs to be sent to installed Khronicle log 
 (`Log.dispatcher.install`).
 
 
+[Ktor]: https://ktor.io/
 [`HttpClient`]: https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client/-http-client/index.html

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Log.warn { metadata ->
 
 ### [Ktor]
 
-A basic `KtorLogger` is available via the `com.juul.khronicle:khronicle-ktor-client:$version` artifact.
+A basic [Ktor] [`Logger`] is available via the `com.juul.khronicle:khronicle-ktor-client:$version` artifact.
 
 To route a [Ktor] [`HttpClient`] instance's logs to Khronicle for logging, simply set
 `KhronicleKtorClientLogger` as the [`HttpClient`]'s logger:
@@ -151,8 +151,9 @@ HttpClient {
 ```
 
 This will cause the [`HttpClient`]'s logs to be sent to installed Khronicle log dispatchers
-(`Log.dispatcher.install`).
+(that were installed via `Log.dispatcher.install`).
 
 
 [Ktor]: https://ktor.io/
 [`HttpClient`]: https://api.ktor.io/ktor-client/ktor-client-core/io.ktor.client/-http-client/index.html
+[`Logger`]: https://api.ktor.io/ktor-utils/io.ktor.util.logging/-logger/index.html


### PR DESCRIPTION
Per https://github.com/JuulLabs/khronicle/issues/60#issuecomment-2503883620, it was suggested that we add additional details about what the Ktor logging artifact is for.

Rendered markdown [here](https://github.com/JuulLabs/khronicle/tree/twyatt/doc/ktor?tab=readme-ov-file#ktor).