### PR TITLE
Don't use the KMP plugin for the lint module

### DIFF
--- a/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/kotlin-conventions.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("repository-conventions")
+    id("test-conventions")
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.atomicfu)
     alias(libs.plugins.kotlinter)
@@ -19,15 +20,5 @@ kotlin {
             implementation(kotlin("test"))
             implementation(libs.kotlinx.coroutines.test)
         }
-    }
-}
-
-tasks.withType<Test>().configureEach {
-    testLogging {
-        events("started", "passed", "skipped", "failed", "standardOut", "standardError")
-        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
-        showExceptions = true
-        showStackTraces = true
-        showCauses = true
     }
 }

--- a/build-logic/src/main/kotlin/test-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/test-conventions.gradle.kts
@@ -1,0 +1,9 @@
+tasks.withType<Test>().configureEach {
+    testLogging {
+        events("started", "passed", "skipped", "failed", "standardOut", "standardError")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+        showExceptions = true
+        showStackTraces = true
+        showCauses = true
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -29,6 +29,7 @@ android-lint = { id = "com.android.lint", version.ref = "android-agp" }
 api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.18.1" }
 atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 dokka = { id = "org.jetbrains.dokka", version = "2.1.0" }
+kotlin-jvm = { id = "org.jetbrains.kotlin.jvm" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "5.3.0" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.36.0" }

--- a/khronicle-android-lint/build.gradle.kts
+++ b/khronicle-android-lint/build.gradle.kts
@@ -1,21 +1,16 @@
 plugins {
-    id("kotlin-conventions")
+    id("repository-conventions")
+    id("test-conventions")
     alias(libs.plugins.android.lint)
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlinter)
     alias(libs.plugins.maven.publish)
 }
 
-kotlin {
-    jvm()
+dependencies {
+    compileOnly(libs.android.lint.api)
 
-    sourceSets {
-        jvmMain.dependencies {
-            compileOnly(libs.android.lint.api)
-        }
-
-        jvmTest.dependencies {
-            implementation(libs.android.lint.api)
-            implementation(libs.android.lint.test)
-            implementation(libs.junit)
-        }
-    }
+    testImplementation(libs.android.lint.api)
+    testImplementation(libs.android.lint.test)
+    testImplementation(libs.junit)
 }


### PR DESCRIPTION
Fixes #189 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build configuration changes only - no runtime code changes. Simplifies the lint module structure by using standard JVM plugin instead of KMP.
> 
> **Overview**
> Converts the `khronicle-android-lint` module from Kotlin Multiplatform to a standard JVM module.
> 
> Extracts test logging configuration from `kotlin-conventions` into a new `test-conventions` plugin that can be applied independently. The lint module now applies `kotlin-jvm` directly instead of inheriting the KMP plugin through `kotlin-conventions`, and uses standard JVM `dependencies` instead of KMP `sourceSets`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa92ae6a1c877da8fd9941a83c81b0a33c795aad. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->