### PR TITLE
Relax consumer Android SDK requirement

### DIFF
--- a/build-logic/src/main/kotlin/android-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/android-conventions.gradle.kts
@@ -7,6 +7,9 @@ kotlin {
     android {
         compileSdk = libs.versions.android.compile.get().toInt()
         minSdk = libs.versions.android.min.get().toInt()
+        aarMetadata {
+            minCompileSdk = libs.versions.android.min.get().toInt()
+        }
 
         namespace = "com.juul.khronicle.${project.name.replace("-", ".")}"
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Under AGP 9, published AAR metadata defaults `minCompileSdk` to the library's `compileSdk`, which unintentionally forces consuming apps to bump their compile SDK even though Khronicle only requires a lower `minSdk` (see JuulLabs/kable#1206 for details of the same issue in Kable, fixed by JuulLabs/kable#1211).

This sets `aarMetadata.minCompileSdk` to `libs.versions.android.min` in the shared `android-conventions` build-logic plugin (applied by `khronicle-core`), so consumers only need to meet Khronicle's minimum supported Android API level.

Verified by running `:khronicle-core:writeAndroidMainAarMetadata` and inspecting the generated `aar-metadata.properties`, which now contains `minCompileSdk=16` (previously defaulted to `36`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9b18a5ab-d729-4ba7-a753-910975978ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9b18a5ab-d729-4ba7-a753-910975978ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

