### PR TITLE
Remove `androidSourceSetLayoutVersion` Gradle option

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 org.gradle.jvmargs=-Xmx4g
-kotlin.mpp.androidSourceSetLayoutVersion=2
 
 # Android Configuration
 android.useAndroidX=true


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Android source layout is version 2 by default and the `kotlin.mpp.androidSourceSetLayoutVersion` property was removed in Kotlin 2.0.0. Keeping it only triggers a deprecation warning during Gradle configuration:

```
w: ⚠️ Deprecated Gradle Property 'kotlin.mpp.androidSourceSetLayoutVersion' Used
The `kotlin.mpp.androidSourceSetLayoutVersion` deprecated property is used in your build.
Solutions:
 * It is unsupported, please stop using it.
 * Android Source Set Layout V2 is enabled by default and can't be changed. Leave your questions here https://youtrack.jetbrains.com/issue/KT-82265
```

This removes the property from `gradle.properties` (the only occurrence in this repo). Verified that Gradle configuration still succeeds (`./gradlew help`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7780adf4-c73e-4cd3-b4e0-65ffddd0bffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7780adf4-c73e-4cd3-b4e0-65ffddd0bffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

