### PR TITLE
Migrate Dokka to V2 mode

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           cache-read-only: true
 
-      - run: ./gradlew :dokkaGenerate
+      - run: ./gradlew dokkaGenerate
       - run: >
           tar
           --dereference --hard-dereference

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -17,11 +17,11 @@ jobs:
         with:
           cache-read-only: true
 
-      - run: ./gradlew dokkaHtmlMultiModule
+      - run: ./gradlew :dokkaGenerate
       - run: >
           tar
           --dereference --hard-dereference
-          --directory build/dokkaHtmlMultiModule
+          --directory build/dokka/html
           -cvf '${{ runner.temp }}/artifact.tar'
           --exclude=.git
           --exclude=.github

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,12 @@ plugins {
     alias(libs.plugins.dokka)
 }
 
+dependencies {
+    dokka(projects.khronicleCore)
+    dokka(projects.khronicleKtorClient)
+    dokka(projects.khronicleTest)
+}
+
 apiValidation {
     nonPublicMarkers.add("com.juul.khronicle.KhronicleInternal")
     ignoredProjects += "khronicle-android-lint"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The GitHub Pages workflow fails on `./gradlew dokkaHtmlMultiModule`:

```
Execution failed for task ':dokkaHtmlMultiModule' (registered by plugin 'org.jetbrains.dokka').
> Cannot run Dokka V1 tasks when V2 mode is enabled.
```

Dokka Gradle plugin 2.2.0 runs in V2 mode, where the V1 `dokkaHtmlMultiModule` task can no longer be executed. Multi-module aggregation in V2 is declared via the `dokka` dependency configuration and generated with the `dokkaGenerate` task ([migration guide](https://kotl.in/dokka-gradle-migration)).

## Changes

- `build.gradle.kts`: declare V2 multi-module aggregation by adding `dokka(...)` dependencies on `khronicle-core`, `khronicle-ktor-client`, and `khronicle-test` (the modules that apply the Dokka plugin via `library-conventions`).
- `.github/workflows/pages.yml`: run `./gradlew :dokkaGenerate` instead of `dokkaHtmlMultiModule`, and tar the V2 output directory `build/dokka/html` instead of `build/dokkaHtmlMultiModule`.

## Verification

- `./gradlew :dokkaGenerate` now completes successfully (`BUILD SUCCESSFUL`).
- The aggregated output at `build/dokka/html` contains `index.html` plus per-module docs for `khronicle-core`, `khronicle-ktor-client`, and `khronicle-test`.
- No remaining references to V1 task names in the repository.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d2518ca-9ebc-47f2-89d7-1ad281b8f074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d2518ca-9ebc-47f2-89d7-1ad281b8f074"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

