### PR TITLE
Add ability to uninstall log dispatchers

### DIFF
--- a/khronicle-core/api/jvm/khronicle-core.api
+++ b/khronicle-core/api/jvm/khronicle-core.api
@@ -18,6 +18,7 @@ public final class com/juul/khronicle/DispatchLogger : com/juul/khronicle/Logger
 	public fun getMinimumLogLevel ()Lcom/juul/khronicle/LogLevel;
 	public fun info (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
 	public final fun install (Lcom/juul/khronicle/Logger;)V
+	public final fun uninstall (Lcom/juul/khronicle/Logger;)V
 	public fun verbose (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
 	public fun warn (Ljava/lang/String;Ljava/lang/String;Lcom/juul/khronicle/ReadMetadata;Ljava/lang/Throwable;)V
 }

--- a/khronicle-core/src/commonMain/kotlin/DispatchLogger.kt
+++ b/khronicle-core/src/commonMain/kotlin/DispatchLogger.kt
@@ -35,6 +35,11 @@ public class DispatchLogger : Logger {
         state.update { DispatcherState(it.consumers + consumer) }
     }
 
+    /** Remove a previously [installed][install] consumer so it no longer receives dispatch calls. */
+    public fun uninstall(consumer: Logger) {
+        state.update { DispatcherState(it.consumers - consumer) }
+    }
+
     /** Uninstall all installed consumers. */
     public fun clear() {
         state.value = EMPTY_STATE

--- a/khronicle-core/src/commonTest/kotlin/DispatchLoggerTests.kt
+++ b/khronicle-core/src/commonTest/kotlin/DispatchLoggerTests.kt
@@ -108,6 +108,41 @@ class DispatchLoggerTests {
     }
 
     @Test
+    fun uninstalledConsumerNoLongerReceivesLogs() {
+        val dispatcher = DispatchLogger()
+        val first = CallListLogger()
+        val second = CallListLogger()
+        dispatcher.install(first)
+        dispatcher.install(second)
+        dispatcher.uninstall(first)
+        val metadata = buildMetadata()
+        val call = Call(LogLevel.Verbose, tag = "test-tag", message = "test-message", Throwable(), metadata)
+        dispatcher.verbose(call.tag, call.message, metadata, call.throwable)
+        assertTrue(first.verboseCalls.isEmpty())
+        assertEquals(call, second.verboseCalls.single())
+        assertTrue(dispatcher.hasConsumers)
+    }
+
+    @Test
+    fun uninstallingLastConsumerResultsInNoConsumers() {
+        val dispatcher = DispatchLogger()
+        val consumer = CallListLogger()
+        dispatcher.install(consumer)
+        dispatcher.uninstall(consumer)
+        assertFalse(dispatcher.hasConsumers)
+        assertEquals(LogLevel.Assert, dispatcher.minimumLogLevel)
+    }
+
+    @Test
+    fun uninstallingConsumerThatWasNeverInstalledIsNoOp() {
+        val dispatcher = DispatchLogger()
+        val installed = CallListLogger()
+        dispatcher.install(installed)
+        dispatcher.uninstall(CallListLogger())
+        assertTrue(dispatcher.hasConsumers)
+    }
+
+    @Test
     fun installingDuplicateConsumerDoesNotResultInDuplicateDispatch() {
         val dispatcher = DispatchLogger()
         val consumer = CallListLogger()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small, symmetric API on logging dispatch with unit tests; no auth or data-path changes.
> 
> **Overview**
> Adds **`uninstall(Logger)`** on `DispatchLogger` so a previously installed consumer can be removed without calling **`clear()`**, which drops every consumer.
> 
> Removal updates the internal consumer set the same way **`install`** adds to it; **`hasConsumers`** and **`minimumLogLevel`** behave as before when the last consumer is uninstalled. The public JVM API dump is updated accordingly.
> 
> New tests cover selective uninstall (other consumers still receive logs), emptying the dispatcher, and uninstalling a logger that was never installed (no-op).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1652f33fc7148a7800d17d2b41a69dadc56c58cd. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->