### PR TITLE
Update android.agp to v9.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android-agp = "9.3.2"
+android-agp = "9.4.0"
 android-compile = "36"
 android-lint = "32.3.2" # If the AGP version is X.Y.Z, then the Lint library version is X+23.Y.Z.
 android-min = "16"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single dependency bump in the version catalog with no application or security logic changes.
> 
> **Overview**
> Bumps the **Android Gradle Plugin (AGP)** version in the Gradle version catalog from `9.3.2` to `9.4.0`.
> 
> That catalog entry feeds the `com.android.kotlin.multiplatform.library` and `com.android.lint` plugin versions; no other version pins or build files change in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b459de88df7f6a5a770379108f6876c0ce528e6e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->